### PR TITLE
jQuery: Fixed error-callback of jqXHR

### DIFF
--- a/jquery/jquery.d.ts
+++ b/jquery/jquery.d.ts
@@ -188,7 +188,7 @@ interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
     /**
      * A function to be called if the request fails.
      */
-    error(xhr: JQueryXHR, textStatus: string, errorThrown: string): void;
+    error(callback: (xhr: JQueryXHR, textStatus: string, errorThrown: string) => any): void;
 }
 
 /**


### PR DESCRIPTION
The original version sees the `error`-property of a jqXHR as a function to set, not a function to be called by user code (since it takes no callback.)

This is not the case. `jqXHR.error` is the same as `jqXHR.fail` ([see jQuery sources](https://github.com/jquery/jquery/blob/c999b6613e1ad458bfaf0187740b52a8faf53418/src/ajax.js#L520)) and fail accepts according to the [jQuery documentation]()

    jqXHR.fail(function( jqXHR, textStatus, errorThrown ) {});

In the jQuery-source [we see](https://github.com/jquery/jquery/blob/c999b6613e1ad458bfaf0187740b52a8faf53418/src/ajax.js#L518) the following:

     deferred.promise( jqXHR )

which will create a `fail`-method on the jqXHR-object, which will take a callback to be executed when the promise is rejected. ([See the deffered.promise doumentation](https://api.jquery.com/deferred.promise/)) 

So the original typing is definitly wrong. 